### PR TITLE
Move the un-dockerized day 1 to an unprivelaged port

### DIFF
--- a/webapp/index.js
+++ b/webapp/index.js
@@ -2,7 +2,7 @@ const express = require("express")
 const proxy = require("express-http-proxy")
 const helmet = require("helmet")
 
-const PORT = process.env.PORT || 80
+const PORT = process.env.PORT || 4000
 
 express()
   .use(

--- a/webapp/index.js
+++ b/webapp/index.js
@@ -2,7 +2,7 @@ const express = require("express")
 const proxy = require("express-http-proxy")
 const helmet = require("helmet")
 
-const PORT = process.env.PORT || 4000
+const PORT = process.env.PORT || 2000
 
 express()
   .use(


### PR DESCRIPTION
It makes sense to have day 1 on port 4000 so that it doesn't crash when you try to run it without sudo privileges.